### PR TITLE
Normalise the logging with other services.

### DIFF
--- a/app.go
+++ b/app.go
@@ -50,7 +50,7 @@ func Echo(conf Config) *echo.Echo {
 	e := echo.New()
 	e.HideBanner = true
 	e.HidePort = true
-	e.Logger = appScopeLogger(logger, conf.AppName, conf.EnvName, conf.BuildVersion)
+	e.Logger = appScopeLogger(logger, conf.AppName, conf.EnvName)
 
 	// the order of these middleware is important - context should be first, error should be after logging ones
 	e.Use(ContextMiddleware(conf.AppName, conf.EnvName, conf.BuildVersion, logger, conf.IsDebug, newRelicApp))

--- a/context.go
+++ b/context.go
@@ -65,7 +65,6 @@ func ContextMiddleware(
 				correlationID,
 				appName,
 				envName,
-				buildVersion,
 			)
 
 			cc := NewContext(c, newRelicApp, logger, correlationID, isDebug, buildVersion)

--- a/logging.go
+++ b/logging.go
@@ -98,13 +98,11 @@ func appScopeLogger(
 	logger *logrus.Logger,
 	appName string,
 	envName string,
-	buildVersion string,
 ) *Logger {
 	entry := logger.WithFields(logrus.Fields{
-		"app":           appName,
-		"env":           envName,
-		"build_version": buildVersion,
-		"scope":         "app",
+		"application": appName,
+		"env":         envName,
+		"scope":       "application",
 	})
 	return &Logger{entry}
 }
@@ -117,12 +115,10 @@ func requestScopeLogger(
 	correlationID string,
 	appName string,
 	envName string,
-	buildVersion string,
 ) *Logger {
 	ctxLogger := logger.WithFields(logrus.Fields{
-		"app":            appName,
+		"application":    appName,
 		"env":            envName,
-		"build_version":  buildVersion,
 		"scope":          "request",
 		"correlation_id": correlationID,
 		"url":            r.RequestURI,


### PR DESCRIPTION
- The app field is application in all the other services so we should use that.
- Build version should be logged at startup and is not needed for each log statement.

We need to consolidate our logging style with the other services to make debugging  service to service and tracing easier.