### PR TITLE
Add method to xecho to get a newrelic scoped client

### DIFF
--- a/context.go
+++ b/context.go
@@ -2,12 +2,11 @@ package xecho
 
 import (
 	"errors"
-	"net/http"
-
 	"github.com/google/uuid"
 	"github.com/labstack/echo"
-	newrelic "github.com/newrelic/go-agent"
+	"github.com/newrelic/go-agent"
 	"github.com/sirupsen/logrus"
+	"net/http"
 )
 
 const correlationIDHeaderName = "Correlation-Id"

--- a/context.go
+++ b/context.go
@@ -107,7 +107,7 @@ func NewContext(
 		IsDebug:       isDebug,
 	}
 
-	// deprecated in favour of context.GetHttpClientWithNewRelic()
+	// deprecated in favour of context.AppendNewRelicToClient()
 	customCtx.HttpClient = NewHttpClient(customCtx, &http.Client{Transport: &http.Transport{}})
 
 	// TODO: build version attribute (and in logs)

--- a/context.go
+++ b/context.go
@@ -47,10 +47,6 @@ func (c *Context) AddNewRelicAttribute(key string, val interface{}) {
 	}
 }
 
-func (c *Context) AppendNewRelicToClient(httpClient *http.Client) *http.Client {
-	return NewHttpClient(c, httpClient)
-}
-
 func ContextMiddleware(
 	appName string,
 	envName string,

--- a/context_test.go
+++ b/context_test.go
@@ -5,8 +5,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
-
 	"github.com/labstack/echo"
 	newrelic "github.com/newrelic/go-agent"
 	"github.com/newrelic/go-agent/_integrations/nrlogrus"
@@ -50,16 +48,6 @@ func TestGetCorrelationID(t *testing.T) {
 	r.Header.Set("Correlation-Id", "testing-id")
 	id = getCorrelationID(r)
 	assert.Equal(t, "testing-id", id)
-}
-
-func TestAppendNewRelicToClient(t *testing.T) {
-	echoCtx, _, _ := getEchoTestCtx()
-	ctx := NewContext(echoCtx, stubNewRelicApp(), &Logger{}, "correlationid", false, "build-1.2.3")
-	//check it uses the same client
-	const timeout = time.Second * 10
-	client := &http.Client{Timeout: timeout}
-	appendedClient := ctx.AppendNewRelicToClient(client)
-	assert.Equal(t, timeout, appendedClient.Timeout)
 }
 
 func NullLogger() *logrus.Logger {

--- a/context_test.go
+++ b/context_test.go
@@ -1,15 +1,17 @@
 package xecho
 
 import (
-	"github.com/labstack/echo"
-	"github.com/newrelic/go-agent"
-	"github.com/newrelic/go-agent/_integrations/nrlogrus"
-	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
+
+	"github.com/labstack/echo"
+	newrelic "github.com/newrelic/go-agent"
+	"github.com/newrelic/go-agent/_integrations/nrlogrus"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestEchoHandler(t *testing.T) {
@@ -48,6 +50,16 @@ func TestGetCorrelationID(t *testing.T) {
 	r.Header.Set("Correlation-Id", "testing-id")
 	id = getCorrelationID(r)
 	assert.Equal(t, "testing-id", id)
+}
+
+func TestAppendNewRelicToClient(t *testing.T) {
+	echoCtx, _, _ := getEchoTestCtx()
+	ctx := NewContext(echoCtx, stubNewRelicApp(), &Logger{}, "correlationid", false, "build-1.2.3")
+	//check it uses the same client
+	const timeout = time.Second * 10
+	client := &http.Client{Timeout: timeout}
+	appendedClient := ctx.AppendNewRelicToClient(client)
+	assert.Equal(t, timeout, appendedClient.Timeout)
 }
 
 func NullLogger() *logrus.Logger {

--- a/context_test.go
+++ b/context_test.go
@@ -1,15 +1,15 @@
 package xecho
 
 import (
-	"io/ioutil"
-	"net/http"
-	"net/http/httptest"
-	"testing"
 	"github.com/labstack/echo"
 	newrelic "github.com/newrelic/go-agent"
 	"github.com/newrelic/go-agent/_integrations/nrlogrus"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
 )
 
 func TestEchoHandler(t *testing.T) {

--- a/http_client.go
+++ b/http_client.go
@@ -1,11 +1,10 @@
 package xecho
 
 import (
+	"github.com/newrelic/go-agent"
 	"net/http"
 	"net/http/httputil"
 	"time"
-
-	newrelic "github.com/newrelic/go-agent"
 )
 
 type loggingTransport struct {

--- a/http_client.go
+++ b/http_client.go
@@ -1,10 +1,11 @@
 package xecho
 
 import (
-	"github.com/newrelic/go-agent"
 	"net/http"
 	"net/http/httputil"
 	"time"
+
+	newrelic "github.com/newrelic/go-agent"
 )
 
 type loggingTransport struct {
@@ -47,14 +48,16 @@ func (t *loggingTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 
 func NewHttpClient(
 	context *Context,
-	isDebug bool,
+	client *http.Client,
 ) *http.Client {
+	// wrap transport
 	loggingTransport := &loggingTransport{
 		inboundContext: context,
-		isDebug:        isDebug,
-		transport:      &http.Transport{},
+		isDebug:        context.IsDebug,
+		transport:      client.Transport,
 	}
-	return &http.Client{Transport: loggingTransport}
+	client.Transport = loggingTransport
+	return client
 }
 
 func debugDumpRequest(r *http.Request, logger *Logger, isDebug bool) error {

--- a/http_client_test.go
+++ b/http_client_test.go
@@ -1,15 +1,17 @@
 package xecho
 
 import (
+	"net/http"
+	"testing"
+	"time"
+
 	"github.com/sirupsen/logrus"
 	"github.com/steinfletcher/apitest"
 	"github.com/stretchr/testify/assert"
-	"net/http"
-	"testing"
 )
 
 func TestHttpClient(t *testing.T) {
-	cli := NewHttpClient(&Context{logger: &Logger{logrus.New().WithFields(logrus.Fields{})}}, true)
+	cli := NewHttpClient(&Context{logger: &Logger{logrus.New().WithFields(logrus.Fields{})}, IsDebug: true}, &http.Client{Transport: &http.Transport{}})
 	apitest.NewMock().
 		HttpClient(cli).
 		Get("http://example.com/message").
@@ -21,4 +23,14 @@ func TestHttpClient(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusAccepted, resp.StatusCode)
+}
+
+func TestHttpClientPassthrough(t *testing.T) {
+
+	timeout := time.Second * 23
+	someClient := &http.Client{
+		Timeout: timeout,
+	}
+	cli := NewHttpClient(&Context{}, someClient)
+	assert.Equal(t, timeout, cli.Timeout)
 }

--- a/http_client_test.go
+++ b/http_client_test.go
@@ -1,13 +1,12 @@
 package xecho
 
 import (
-	"net/http"
-	"testing"
-	"time"
-
 	"github.com/sirupsen/logrus"
 	"github.com/steinfletcher/apitest"
 	"github.com/stretchr/testify/assert"
+	"net/http"
+	"testing"
+	"time"
 )
 
 func TestHttpClient(t *testing.T) {


### PR DESCRIPTION
We want to use the client created by xecho as it adds a newrelic external wrapper which would be good for monitoring. However, the client returned by the context is a blank client. 
Our application needs multiple clients with different config like additional root CAs and adjusted timeouts. 
We could update the returned client on every request, but I think its better to provide a wrapper function like in this PR so we can setup only once and whatever client we have we can append the newrelic functionality. I've also deprecated the newclient on every request.
Open to thoughts...