### PR TITLE
GO-10572: Add 'service_name' attribute to logger to attach logs to APM entity in NewRelic

### DIFF
--- a/context.go
+++ b/context.go
@@ -47,10 +47,8 @@ func (c *Context) AddNewRelicAttribute(key string, val interface{}) {
 }
 
 func ContextMiddleware(
-	appName string,
-	envName string,
 	buildVersion string,
-	logger *logrus.Logger,
+	logger *logrus.Entry,
 	isDebug bool,
 	newRelicApp newrelic.Application,
 ) echo.MiddlewareFunc {
@@ -64,8 +62,6 @@ func ContextMiddleware(
 				c.Path(),
 				ip,
 				correlationID,
-				appName,
-				envName,
 			)
 
 			cc := NewContext(c, newRelicApp, logger, correlationID, isDebug, buildVersion)

--- a/context_test.go
+++ b/context_test.go
@@ -22,7 +22,10 @@ func TestEchoHandler(t *testing.T) {
 
 func TestContextMiddleware(t *testing.T) {
 	ctx, _, _ := getEchoTestCtx()
-	mw := ContextMiddleware("testApp", "testEnv", "build-1.2.3", NullLogger(), true, stubNewRelicApp())
+	mw := ContextMiddleware("build-1.2.3", NullLogger().WithFields(logrus.Fields{
+		"application": "testApp",
+		"environment": "testEnv",
+	}), true, stubNewRelicApp())
 	hCalled := false
 	h := EchoHandler(func(c *Context) error {
 		hCalled = true

--- a/logging.go
+++ b/logging.go
@@ -77,32 +77,14 @@ func dumpResponse(c *Context, drw *debugResponseWriter) {
 	}
 }
 
-func appScopeLogger(
-	logger *logrus.Logger,
-	appName string,
-	envName string,
-) *Logger {
-	entry := logger.WithFields(logrus.Fields{
-		"application": appName,
-		"env":         envName,
-		"scope":       "application",
-	})
-	return &Logger{entry}
-}
-
 func requestScopeLogger(
-	logger *logrus.Logger,
+	logger *logrus.Entry,
 	r *http.Request,
 	route string,
 	ip string,
 	correlationID string,
-	appName string,
-	envName string,
 ) *Logger {
 	ctxLogger := logger.WithFields(logrus.Fields{
-		"application":    appName,
-		"env":            envName,
-		"scope":          "request",
 		"correlation_id": correlationID,
 		"url":            r.RequestURI,
 		"route":          route,


### PR DESCRIPTION
- By default all logs produced using xecho will always include the `service_name` attribute among others